### PR TITLE
✨ Add the ability to build an entire workspace or a specific executable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ use cargo_metadata::Message;
 pub struct BinTestBuilder {
     build_workspace: bool,
     specific_executable: Option<String>,
+    quiet: bool,
 }
 
 /// Access to binaries build by 'cargo build'
@@ -86,6 +87,7 @@ impl BinTestBuilder {
         Self {
             build_workspace: false,
             specific_executable: None,
+            quiet: false,
         }
     }
 
@@ -105,6 +107,12 @@ impl BinTestBuilder {
             specific_executable: Some(executable.into()),
             ..self
         }
+    }
+
+    /// Allow disabling extra output from the `cargo build` run
+    #[must_use]
+    pub fn quiet(self, quiet: bool) -> Self {
+        Self { quiet, ..self }
     }
 
     /// Constructs the `BinTest`, running `cargo build` with the configured options
@@ -151,6 +159,10 @@ impl BinTest {
 
         if let Some(executable) = builder.specific_executable {
             cargo_build.args(["--bin", &executable]);
+        }
+
+        if builder.quiet {
+            cargo_build.arg("--quiet");
         }
 
         let mut cargo_result = cargo_build.spawn().expect("'cargo build' success");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,13 @@ pub use std::process::{Command, Stdio};
 pub use cargo_metadata::camino::Utf8PathBuf;
 use cargo_metadata::Message;
 
+/// Allows configuration of a workspace to find an executable in
+#[must_use]
+pub struct BinTestBuilder {
+    build_workspace: bool,
+    specific_executable: Option<String>,
+}
+
 /// Access to binaries build by 'cargo build'
 pub struct BinTest {
     build_executables: BTreeMap<String, Utf8PathBuf>,
@@ -72,10 +79,62 @@ const RELEASE_BUILD: bool = true;
 #[cfg(debug_assertions)]
 const RELEASE_BUILD: bool = false;
 
+impl BinTestBuilder {
+    /// Constructs a default builder that does not build workspace executables
+    #[must_use]
+    pub fn new() -> BinTestBuilder {
+        Self {
+            build_workspace: false,
+            specific_executable: None,
+        }
+    }
+
+    /// Allow building all executables in a workspace
+    #[must_use]
+    pub fn build_workspace(self, workspace: bool) -> Self {
+        Self {
+            build_workspace: workspace,
+            ..self
+        }
+    }
+
+    /// Allow only building a specific executable in the case of multiple in a workspace/package
+    #[must_use]
+    pub fn build_executable<S: Into<String>>(self, executable: S) -> Self {
+        Self {
+            specific_executable: Some(executable.into()),
+            ..self
+        }
+    }
+
+    /// Constructs the `BinTest`, running `cargo build` with the configured options
+    pub fn build(self) -> BinTest {
+        BinTest::new_with_builder(self)
+    }
+}
+
 impl BinTest {
     /// Runs 'cargo build' and register all build executables.
     /// Executables are identified by their name, without path and filename extension.
     pub fn new() -> BinTest {
+        Self::new_with_builder(BinTestBuilder::new())
+    }
+
+    /// Gives an `(name, path)` iterator over all executables found
+    pub fn list_executables(&self) -> std::collections::btree_map::Iter<'_, String, Utf8PathBuf> {
+        self.build_executables.iter()
+    }
+
+    /// Constructs a 'std::process::Command' for the given executable name
+    pub fn command(&self, name: &str) -> Command {
+        Command::new(
+            self.build_executables
+                .get(name)
+                .unwrap_or_else(|| panic!("no such executable <<{}>>", name)),
+        )
+    }
+
+    fn new_with_builder(builder: BinTestBuilder) -> Self {
         let mut cargo_build = Command::new(env("CARGO").unwrap_or_else(|| OsString::from("cargo")));
 
         cargo_build
@@ -84,6 +143,14 @@ impl BinTest {
 
         if RELEASE_BUILD {
             cargo_build.arg("--release");
+        }
+
+        if builder.build_workspace {
+            cargo_build.arg("--workspace");
+        }
+
+        if let Some(executable) = builder.specific_executable {
+            cargo_build.args(["--bin", &executable]);
         }
 
         let mut cargo_result = cargo_build.spawn().expect("'cargo build' success");
@@ -103,20 +170,6 @@ impl BinTest {
         }
 
         BinTest { build_executables }
-    }
-
-    /// Gives an `(name, path)` iterator over all executables found
-    pub fn list_executables(&self) -> std::collections::btree_map::Iter<'_, String, Utf8PathBuf> {
-        self.build_executables.iter()
-    }
-
-    /// Constructs a 'std::process::Command' for the given executable name
-    pub fn command(&self, name: &str) -> Command {
-        Command::new(
-            self.build_executables
-                .get(name)
-                .unwrap_or_else(|| panic!("no such executable <<{}>>", name)),
-        )
     }
 }
 


### PR DESCRIPTION
This PR adds a `BinTestBuilder` struct, which can be used to add the `--workspace` flag to `cargo build` and/or to build a specific executable with the `--bin` flag.

This was all fine for my specific use-case, but I'm very open to suggestions or alternative API ideas - if we're happy with this though, we could also use it to handle the `RELEASE_BUILD` flag too, though I wouldn't necessarily do that as part of this PR